### PR TITLE
process dependencies in topological order

### DIFF
--- a/fixtures/complex-march.glsl
+++ b/fixtures/complex-march.glsl
@@ -1,0 +1,28 @@
+#pragma glslify: Ray = require('./complex-ray.glsl')
+#pragma glslify: RayResult = require('./complex-ray-result.glsl')
+
+RayResult rayBail() {
+  return RayResult(0.0, 0.0, false);
+}
+
+RayResult march(Ray source, float maxd, float precis) {
+  float latest = precis * 2.0;
+  float dist = +0.0;
+  float type = -1.0;
+  RayResult res = rayBail();
+
+  for (int i = 0; i < 99; i++) {
+    if (latest < precis || dist > maxd) break;
+
+    res = map(source.ro + source.rd * dist);
+    dist += res.d;
+  }
+
+  return dist >= maxd
+    ? rayBail();
+    : res
+}
+
+Ray march(Ray ray) {
+  return march(ray, 20.0, 0.001);
+}

--- a/fixtures/complex-ray-result.glsl
+++ b/fixtures/complex-ray-result.glsl
@@ -1,0 +1,7 @@
+struct Result {
+  float d;
+  float type;
+  bool hit;
+};
+
+#pragma glslify: export(Result)

--- a/fixtures/complex-ray.glsl
+++ b/fixtures/complex-ray.glsl
@@ -1,0 +1,6 @@
+struct Ray {
+  vec3 ro;
+  vec3 rd;
+};
+
+#pragma glslify: export(Ray)

--- a/fixtures/complex.glsl
+++ b/fixtures/complex.glsl
@@ -1,0 +1,29 @@
+precision mediump float;
+
+#pragma glslify: RayResult = require('./complex-ray-result')
+#pragma glslify: Ray = require('./complex-ray')
+
+RayResult doModel(vec3 p);
+
+#pragma glslify: march = require('./complex-march', map = doModel)
+
+RayResult doModel(vec3 p) {
+  float d = length(p);
+  float id = 1.0;
+
+  return RayResult(d, id, true);
+}
+
+void main() {
+  vec3 color = vec3(0);
+  vec3 rd = normalize(vec3(1));
+  vec3 ro = vec3(0);
+
+  RayResult t = Ray(ro, rd);
+
+  if (t.hit) {
+    color = vec3(t.d);
+  }
+
+  gl_FragColor = vec4(color, 1);
+}

--- a/fixtures/square.vert
+++ b/fixtures/square.vert
@@ -1,0 +1,7 @@
+precision mediump float;
+
+attribute vec2 position;
+
+void main() {
+  gl_Position = vec4(position, 1, 1);
+}

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var descope  = require('glsl-token-descope')
 var string   = require('glsl-token-string')
 var scope    = require('glsl-token-scope')
 var depth    = require('glsl-token-depth')
+var topoSort = require('./lib/topo-sort')
 
 module.exports = function(deps) {
   return inject(Bundle(deps).src, {
@@ -15,6 +16,9 @@ module.exports = function(deps) {
 function Bundle(deps) {
   if (!(this instanceof Bundle)) return new Bundle(deps)
 
+  //Reorder dependencies topologically
+  deps = topoSort(deps)
+  
   this.depList    = deps
   this.depIndex   = indexBy(deps, 'id')
   this.exported   = {}
@@ -25,8 +29,9 @@ function Bundle(deps) {
 
   for (var i = 0; i < deps.length; i++) {
     var dep = deps[i]
+    dep.bundle = this.bundle(dep)
     if (dep.entry) {
-      this.src = this.src.concat(this.bundle(dep).tokens)
+      this.src = this.src.concat(dep.bundle.tokens)
     }
   }
 
@@ -78,7 +83,7 @@ Bundle.prototype.bundle = function(dep) {
         continue
       }
 
-      var targetBundle = this.bundle(target)
+      var targetBundle = target.bundle
       var targetTokens = targetBundle.tokens
       var targetExport = targetBundle.exports
       var targetIndex  = tokens.indexOf(token)

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function Bundle(deps) {
 
   //Reorder dependencies topologically
   deps = topoSort(deps)
-  
+
   this.depList    = deps
   this.depIndex   = indexBy(deps, 'id')
   this.exported   = {}

--- a/lib/topo-sort.js
+++ b/lib/topo-sort.js
@@ -1,0 +1,72 @@
+'use strict'
+
+module.exports = topoSort
+
+//Permutes the dependencies into topological order
+function topoSort(deps) {
+
+  //Build reversed adjacency list
+  var adj = {}
+  var inDegree = {}
+  var index = {}
+  deps.forEach(function(dep) {
+    var v = dep.id
+    var nbhd = Object.keys(dep.deps)
+    index[dep.id] = dep
+    inDegree[v] = nbhd.length
+    nbhd.forEach(function(filename) {
+      var u = dep.deps[filename]
+      if(adj[u]) {
+        adj[u].push(v)
+      } else {
+        adj[u] = [v]
+      }
+    })
+  })
+
+  //Initialize toVisit queue
+  var result = []
+  var inverse = {}
+  deps.forEach(function(dep) {
+    var v = dep.id
+    if(!adj[v]) {
+      adj[v] = []
+    }
+    if(inDegree[v] === 0) {
+      inverse[v] = result.length
+      result.push(v)
+    }
+  })
+
+  //Run BFS
+  for(var ptr=0; ptr<result.length; ptr++) {
+    var v = result[ptr]
+    adj[v].forEach(function(u) {
+      if(--inDegree[u] === 0) {
+        inverse[u] = result.length
+        result.push(u)
+      }
+    })
+  }
+
+  if(result.length !== deps.length) {
+    throw new Error('cyclic dependency')
+  }
+
+  //Relabel dependencies
+  return result.map(function(v) {
+    var dep = index[v]
+    var deps = dep.deps
+    var ndeps = {}
+    Object.keys(deps).forEach(function(filename) {
+      ndeps[filename] = inverse[deps[filename]]|0
+    })
+    return {
+      id:     inverse[v]|0,
+      deps:   ndeps,
+      file:   dep.file,
+      source: dep.source,
+      entry:  dep.entry
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "glsl-tokenizer": "^2.0.2"
   },
   "devDependencies": {
+    "gl": "^2.1.5",
+    "gl-shader": "^4.0.6",
     "glslify-deps": "^1.2.1",
     "tape": "^3.5.0"
   },

--- a/test/complex-valid-shader.js
+++ b/test/complex-valid-shader.js
@@ -1,0 +1,29 @@
+var Shader = require('./utils/fragment-shader')
+var deps   = require('glslify-deps')
+var test   = require('tape')
+var path   = require('path')
+var bundle = require('../')
+var fs     = require('fs')
+
+var fixture = path.resolve(__dirname, '..', 'fixtures', 'complex.glsl')
+
+test('complex but valid shader', function(t) {
+  var depper = deps()
+
+  depper.add(fixture, function(err, modules) {
+    if (err) return t.ifError(err)
+
+    var src = bundle(modules)
+
+    try {
+      Shader(src)
+    } catch (e) {
+      console.error(src)
+      t.fail(e.message)
+    } finally {
+      t.pass('shader complied successfully')
+    }
+
+    t.end()
+  })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 require('./lazy-variable-name-check')
 require('./define-after-version')
+require('./complex-valid-shader')

--- a/test/lazy-variable-name-check.js
+++ b/test/lazy-variable-name-check.js
@@ -16,13 +16,13 @@ test('lazy variable rename check', function(t) {
 
     t.equal(src.match(/uVec/g).length, 3, '3 occurences of uVec')
     t.equal(src.match(/uVec.x/g).length, 2, '2 occurences of uVec.x')
-    t.equal(src.match(/Light_3_0/g).length, 7, '7 occurences of Light_3_0')
-    t.equal(src.match(/alongside_2_1/g).length, 2, '2 occurences of alongside_2_1')
-    t.equal(src.match(/another_2_2/g).length, 4, '4 occurences of another_2_2')
+    t.equal(src.match(/Light_\d_0/g).length, 7, '7 occurences of Light_*_0')
+    t.equal(src.match(/alongside_\d_1/g).length, 2, '2 occurences of alongside_*_1')
+    t.equal(src.match(/another_\d_2/g).length, 4, '4 occurences of another_*_2')
     t.equal(src.match(/4\.0/g).length, 3, '3 occurences of 4.0')
     t.equal(src.match(/b\.color/g).length, 1, '1 occurence of b.color')
     t.equal(src.match(/b\.position/g).length, 2, '2 occurences of b.position')
-    t.equal(src.match(/sibling_1_3/g).length, 2, '2 occurences of sibling_1_3')
+    t.equal(src.match(/sibling_\d_3/g).length, 2, '2 occurences of sibling_*_3')
     t.equal(src.match(/\#define GLSLIFY 1/g).length, 1, '1 occurences of #define GLSLIFY 1')
 
     t.end()

--- a/test/utils/fragment-shader.js
+++ b/test/utils/fragment-shader.js
@@ -1,0 +1,14 @@
+var Shader = require('gl-shader')
+var path = require('path')
+var fs = require('fs')
+var GL = require('gl')
+var gl
+
+var vert = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'fixtures', 'square.vert')
+, 'utf8')
+
+module.exports = function (source) {
+  gl = gl || GL(2, 2)
+  return Shader(gl, vert, source)
+}


### PR DESCRIPTION
This should fix https://github.com/stackgl/glslify/issues/44

Note that a few of the test cases break now because they are over constraining the variable renamings.  This is still sort of a first pass at things.  I'd like to make the file names use the path as a hash and then just concatenate all the scripts in one shot.