### PR TITLE
Use hash based renaming for dependencies

### DIFF
--- a/fixtures/complex-march.glsl
+++ b/fixtures/complex-march.glsl
@@ -18,11 +18,15 @@ RayResult march(Ray source, float maxd, float precis) {
     dist += res.d;
   }
 
-  return dist >= maxd
-    ? rayBail();
-    : res
+  if(dist >= maxd) {
+    return rayBail();
+  }
+
+  return res;
 }
 
-Ray march(Ray ray) {
+RayResult march(Ray ray) {
   return march(ray, 20.0, 0.001);
 }
+
+#pragma glslify: export(march)

--- a/fixtures/complex.glsl
+++ b/fixtures/complex.glsl
@@ -19,7 +19,7 @@ void main() {
   vec3 rd = normalize(vec3(1));
   vec3 ro = vec3(0);
 
-  RayResult t = Ray(ro, rd);
+  RayResult t = march(Ray(ro, rd));
 
   if (t.hit) {
     color = vec3(t.d);

--- a/fixtures/multiple-mapped-child.glsl
+++ b/fixtures/multiple-mapped-child.glsl
@@ -1,0 +1,5 @@
+float mappedChild() {
+  return map(vec3(0));
+}
+
+#pragma glslify: export(mappedChild)

--- a/fixtures/multiple-mapped.glsl
+++ b/fixtures/multiple-mapped.glsl
@@ -1,0 +1,20 @@
+precision mediump float;
+
+float source1(vec3 p);
+float source2(vec3 p);
+
+#pragma glslify: map1 = require('./multiple-mapped-child', map = source1)
+#pragma glslify: map2 = require('./multiple-mapped-child', map = source2)
+#pragma glslify: map3 = require('./multiple-mapped-child', map = source1)
+
+float source1(vec3 p) {
+  return length(p) - 1.0;
+}
+
+float source2(vec3 p) {
+  return length(p) - 2.0;
+}
+
+void main() {
+  gl_FragColor = vec4(map1(), map2(), map3(), 1);
+}

--- a/index.js
+++ b/index.js
@@ -152,7 +152,11 @@ proto.bundle = function (entry) {
 
     //Rename tokens
     var parsedTokens = dep.parsed.tokens.map(cloneToken)
+    var parsedDefs = defines(parsedTokens)
     var tokens = descope(parsedTokens, function(local, token) {
+      if (parsedDefs[local]) {
+        return local
+      }
       return rename[local] || (local + suffix)
     })
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "glsl-token-scope": "^1.1.1",
     "glsl-token-string": "^1.0.1",
     "glsl-token-whitespace-trim": "^1.0.0",
-    "glsl-tokenizer": "^2.0.2"
+    "glsl-tokenizer": "^2.0.2",
+    "murmurhash-js": "^1.0.0"
   },
   "devDependencies": {
     "gl": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "glsl-token-string": "^1.0.1",
     "glsl-token-whitespace-trim": "^1.0.0",
     "glsl-tokenizer": "^2.0.2",
-    "murmurhash-js": "^1.0.0"
+    "murmurhash-js": "^1.0.0",
+    "shallow-copy": "0.0.1"
   },
   "devDependencies": {
     "gl": "^2.1.5",

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
 require('./lazy-variable-name-check')
 require('./define-after-version')
 require('./complex-valid-shader')
+require('./multiple-mapped')

--- a/test/lazy-variable-name-check.js
+++ b/test/lazy-variable-name-check.js
@@ -15,13 +15,13 @@ test('lazy variable rename check', function (t) {
 
     t.equal(src.match(/uVec/g).length, 3, '3 occurences of uVec')
     t.equal(src.match(/uVec.x/g).length, 2, '2 occurences of uVec.x')
-    t.equal(src.match(/Light_\d_0/g).length, 7, '7 occurences of Light_*_0')
-    t.equal(src.match(/alongside_\d_1/g).length, 2, '2 occurences of alongside_*_1')
-    t.equal(src.match(/another_\d_2/g).length, 4, '4 occurences of another_*_2')
+    t.equal(src.match(/Light_\d+/g).length, 7, '7 occurences of Light_*_0')
+    t.equal(src.match(/alongside_\d+/g).length, 2, '2 occurences of alongside_*_1')
+    t.equal(src.match(/another_\d+/g).length, 4, '4 occurences of another_*_2')
     t.equal(src.match(/4\.0/g).length, 3, '3 occurences of 4.0')
     t.equal(src.match(/b\.color/g).length, 1, '1 occurence of b.color')
     t.equal(src.match(/b\.position/g).length, 2, '2 occurences of b.position')
-    t.equal(src.match(/sibling_\d_3/g).length, 2, '2 occurences of sibling_*_3')
+    //t.equal(src.match(/sibling_\d_3/g).length, 2, '2 occurences of sibling_*_3')
     t.equal(src.match(/\#define GLSLIFY 1/g).length, 1, '1 occurences of #define GLSLIFY 1')
 
     t.end()

--- a/test/lazy-variable-name-check.js
+++ b/test/lazy-variable-name-check.js
@@ -15,13 +15,13 @@ test('lazy variable rename check', function (t) {
 
     t.equal(src.match(/uVec/g).length, 3, '3 occurences of uVec')
     t.equal(src.match(/uVec.x/g).length, 2, '2 occurences of uVec.x')
-    t.equal(src.match(/Light_\d+/g).length, 7, '7 occurences of Light_*_0')
-    t.equal(src.match(/alongside_\d+/g).length, 2, '2 occurences of alongside_*_1')
-    t.equal(src.match(/another_\d+/g).length, 4, '4 occurences of another_*_2')
+    t.equal(src.match(/Light_\d+/g).length, 7, '7 occurences of Light_*')
+    t.equal(src.match(/alongside_\d+/g).length, 2, '2 occurences of alongside_*')
+    t.equal(src.match(/another_\d+/g).length, 4, '4 occurences of another_*')
     t.equal(src.match(/4\.0/g).length, 3, '3 occurences of 4.0')
     t.equal(src.match(/b\.color/g).length, 1, '1 occurence of b.color')
     t.equal(src.match(/b\.position/g).length, 2, '2 occurences of b.position')
-    //t.equal(src.match(/sibling_\d_3/g).length, 2, '2 occurences of sibling_*_3')
+    t.equal(src.match(/sibling_\d+/g).length, 2, '2 occurences of sibling_*')
     t.equal(src.match(/\#define GLSLIFY 1/g).length, 1, '1 occurences of #define GLSLIFY 1')
 
     t.end()

--- a/test/multiple-mapped.js
+++ b/test/multiple-mapped.js
@@ -1,0 +1,47 @@
+var Shader = require('./utils/fragment-shader')
+var deps = require('glslify-deps')
+var test = require('tape')
+var path = require('path')
+var bundle = require('../')
+
+var fixture = path.resolve(__dirname, '..', 'fixtures', 'multiple-mapped.glsl')
+
+test('multiple mappings of the same module', function (t) {
+  var depper = deps()
+
+  depper.add(fixture, function (err, modules) {
+    if (err) return t.ifError(err)
+
+    var src = bundle(modules)
+
+    t.equal(src.match(/mappedChild_\d+/g).length, 5, '5 occurences of mappedChild_*')
+    t.equal(numberOfSuffixes(src, /mappedChild_(\d+)/g), 2, '2 suffixed versions of mappedChild_*')
+
+    var suffixes = src.match(/mappedChild_(\d+)\(\), mappedChild_(\d+)\(\), mappedChild_(\d+)\(\)/)
+    t.equal(suffixes[1], suffixes[3], 'multiple require calls with the same mapping resolve to the same symbol')
+    t.notEqual(suffixes[1], suffixes[2], 'multiple require calls with different mappings resolve to different symbols')
+
+    try {
+      Shader(src)
+    } catch (e) {
+      console.error(src)
+      t.fail(e.message)
+      return t.end()
+    }
+
+    t.pass('shader compiled successfully')
+
+    t.end()
+  })
+})
+
+function numberOfSuffixes (src, regex) {
+  var suffixes = {}
+
+  src.replace(regex, function (_, suffix) {
+    suffixes[suffix] = true
+    return _
+  })
+
+  return Object.keys(suffixes).length
+}


### PR DESCRIPTION
This patch implements content based renaming for dependencies.  So instead of giving variables names like: `Light_2_3_4_...`, the new naming scheme renames variables to `Light_<hash>` where `hash` is a hash of the dependency index and the arguments to the bundle.  This reduces code duplication due to nested dependencies and also makes reusing structures between modules (as in the complex dependency case) easier to do.

One problem right now though is that preprocessor macros aren't renamed.  I think that this is a bug in glsl-descope-tokens, but I'm not sure.  @hughsk or @mattdesl: Do you know how glslify-bundle handled renaming macro tokens (like `#define PI 3.14...`) previously?