### PR TITLE
[WIP]Sourcemaps support

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var copy = require('shallow-copy')
 // Mock glsl-token-string
 // as it doesn't support sourcemaps
 const sourceMap = require('source-map')
+const convert = require('convert-source-map');
 const string = (tokens) => {
   const output = [];
   const map = new sourceMap.SourceMapGenerator();
@@ -47,8 +48,11 @@ const string = (tokens) => {
       (column + token.data.length)
   })
 
-  console.log(map.toString())
-  return output.join('');
+  const src = output.join('')
+  const mapJSON = map.toString()
+  const mapComment = convert.fromJSON(mapJSON).toComment()
+
+  return src + '\n' + mapComment
 }
 
 module.exports = function (deps, opts) {

--- a/index.js
+++ b/index.js
@@ -7,16 +7,55 @@ var inject = require('glsl-inject-defines')
 var defines = require('glsl-token-defines')
 var descope = require('glsl-token-descope')
 var clean = require('./lib/clean-suffixes')
-var string = require('glsl-token-string')
+// var string = require('glsl-token-string')
 var scope = require('glsl-token-scope')
 var depth = require('glsl-token-depth')
 var topoSort = require('./lib/topo-sort')
 var copy = require('shallow-copy')
 
-module.exports = function (deps) {
-  return inject(Bundle(deps).src, {
-    GLSLIFY: 1
+// Mock glsl-token-string
+// as it doesn't support sourcemaps
+const sourceMap = require('source-map')
+const string = (tokens) => {
+  const output = [];
+  const map = new sourceMap.SourceMapGenerator();
+
+  let line = 1
+  let column = 1
+
+  tokens.forEach(token => {
+    if (token.type === 'eof') return
+
+    output.push(token.data)
+
+    map.addMapping({
+      source: token.source,
+      original: {
+        line: token.original.line,
+        column: token.original.column,
+      },
+      generated: {
+        line: line,
+        column: column
+      },
+    });
+
+    const lines = token.data.split(/\r\n|\r|\n/)
+    line += lines.length - 1
+    column = lines.length > 1 ?
+      lines[lines.length - 1].length :
+      (column + token.data.length)
   })
+
+  console.log(map.toString())
+  return output.join('');
+}
+
+module.exports = function (deps, opts) {
+  // return inject(Bundle(deps, opts).src, {
+  //   GLSLIFY: 1
+  // })
+  return Bundle(deps, opts).src
 }
 
 function Bundle (deps) {
@@ -44,7 +83,7 @@ function Bundle (deps) {
   }
 
   this.src = string(this.src)
-  this.src = string(clean(trim(tokenize(this.src))))
+  // this.src = string(clean(trim(tokenize(this.src))))
 }
 
 var proto = Bundle.prototype
@@ -59,6 +98,14 @@ proto.preprocess = function (dep) {
 
   for (var i = 0; i < tokens.length; i++) {
     var token = tokens[i]
+    token.source = dep.file
+
+    // Save original position
+    token.original = {
+      line: token.line,
+      column: Math.max(token.column - token.data.length + 1, 0)
+    }
+
     if (token.type !== 'preprocessor') continue
     if (!glslifyPreprocessor(token.data)) continue
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "glsl-token-whitespace-trim": "^1.0.0",
     "glsl-tokenizer": "^2.0.2",
     "murmurhash-js": "^1.0.0",
-    "shallow-copy": "0.0.1"
+    "shallow-copy": "0.0.1",
+    "source-map": "^0.5.6"
   },
   "devDependencies": {
     "gl": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shallow-copy": "0.0.1"
   },
   "devDependencies": {
-    "gl": "^2.1.5",
+    "gl": "^4.0.3",
     "gl-shader": "^4.0.6",
     "glslify-deps": "^1.2.1",
     "standard": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "http://hughsk.io/"
   },
   "dependencies": {
+    "convert-source-map": "^1.5.0",
     "glsl-inject-defines": "^1.0.1",
     "glsl-token-defines": "^1.0.0",
     "glsl-token-depth": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gl-shader": "^4.0.6",
     "glslify-deps": "^1.2.1",
     "standard": "^5.4.1",
+    "tap-spec": "^4.1.1",
     "tape": "^3.5.0"
   },
   "repository": {


### PR DESCRIPTION
I write glsl codes in Atom + linter-glsl, but the linter doesn't support glsl files using glslify, so I tried to hack on linter-glsl to supporet glslify.
I succeeded to get correct error messages by running `glslify` before `glslangValidator`, but the line number and column are for bundled code.
So it would be great if glslify supports sourcemaps!

In this PR,  I succeeded to get sourcemaps like this:
https://gist.github.com/fand/d64754980900490b81867340a13c9643#file-out-glsl

With [mozilla/source-map], I could parsed the sourcemap and to get positions of original code positions from bundled code with `consumer.originalPositionFor()`.
https://gist.github.com/fand/d64754980900490b81867340a13c9643#file-parsesourcemaps-js

However, I had to disable some modules because they don't support sourcemaps.
To achieve complete glslify support we may need to fix following modules...?

- glsl-token-whitespace-trim
- glsl-tokenizer/string
- glsl-inject-defines
- glsl-token-defines
- glsl-token-string

Should I continue and send PRs to these repos...?
Please give me advice! 🐈 